### PR TITLE
Lean serveless.yml && Pip install via Docker

### DIFF
--- a/celery_serverless/data/serverless.yml
+++ b/celery_serverless/data/serverless.yml
@@ -15,19 +15,14 @@ service: celery-worker # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: python3.6
 
 functions:
   celery_serverless_worker:
     handler: celery_serverless.handler_worker
-
-    events:
-#      - s3: ${env:BUCKET}
-#      - schedule: rate(10 minutes)
-#      - sns: greeter-topic
-     - http:
-         path: celery/worker
-         method: post
+    runtime: python3.6
+    timeout: 10  # Up to 300
+    environment:
+      CELERY_WORKER_APP: 'project'
 
 custom:
   pythonRequirements:

--- a/celery_serverless/data/serverless.yml
+++ b/celery_serverless/data/serverless.yml
@@ -27,7 +27,7 @@ functions:
 custom:
   pythonRequirements:
     zip: false
-    # dockerizePip: true
+    dockerizePip: 'non-linux'
     invalidateCaches: false
     pipCmdExtraArgs:
       - --cache-dir

--- a/celery_serverless/deployer.py
+++ b/celery_serverless/deployer.py
@@ -50,8 +50,8 @@ def _install_serverless_yml():
             click.secho(dedent("""
             # serverless.yml
             functions:
-              worker:
-                handler: celery_serverless.handler.worker
+              celery_serverless_worker:
+                handler: celery_serverless.handler_worker
             """), bold=True, err=True)
             should_copy_to = os.path.join(should_copy_to, 'serverless.yml.celery')
 


### PR DESCRIPTION
Moved the handler stuff into its segment on the configfile, to be less intrusive over users files.

If not on Linux, demand use of Docker to pip install. Fixes binary incompatibilities.