### PR TITLE
Fix reuse of Celery workers & Simpler invocation

### DIFF
--- a/celery_serverless/invoker.py
+++ b/celery_serverless/invoker.py
@@ -126,6 +126,10 @@ class Invoker(object):
         return output
 
 
+def invoke(config=None, *args, **kwargs):
+    return Invoker(config=config).invoke_main(*args, **kwargs)
+
+
 def _get_serverless_name(config):
     for name, options in config['functions'].items():
         if options.get('handler') == CELERY_HANDLER_PATH:

--- a/celery_serverless/task.py
+++ b/celery_serverless/task.py
@@ -17,7 +17,7 @@ def trigger_invoke(task=None, *args, **kwargs):
         logging.warning("Serverless worker will probable not get the task,"
                         " as its queue %s is probable not being listened there",
                         kwargs['queue'])
-    return invoker.Invoker().invoke_main()
+    return invoker.invoke()
 
 
 class TriggerServerlessBeforeMixin(object):

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -5,6 +5,7 @@ import logging
 from functools import partial
 
 import celery.bin.celery
+import celery.worker.state
 from celery.signals import celeryd_init, worker_ready
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,9 @@ def spawn_worker(softlimit:'seconds'=None, hardlimit:'seconds'=None, **options):
     try:
         celery.bin.celery.main(command_argv)  # Will block until worker dies.
     except SystemExit as e:  # Worker is dead.
+        state = celery.worker.state
+        state.should_stop = False
+        state.should_terminate = False
         return e
     raise RuntimeError('Is the worker left running?')
 


### PR DESCRIPTION
Without this, the Celery worker fails on AWS on 2nd call for the same machine

Provided a simpler interface for invocation too.