### PR TITLE
Removed Ctrl+C calls via `raise WorkerShutdown()`

### DIFF
--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -8,6 +8,7 @@ import os
 import importlib
 import logging
 
+logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger.setLevel('DEBUG')
 

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -57,6 +57,12 @@ def worker(event, context):
         _maybe_call_hook(_pre_handler_call_envvar, locals())
 
         try:
+            request_id = context.aws_request_id
+        except AttributeError:
+            request_id = '(unknown)'
+        logger.info('START: Handle request ID: %s', request_id)
+
+        try:
             remaining_seconds = context.get_remaining_time_in_millis() / 1000.0
         except Exception as e:
             logger.exception('Could not got remaining_seconds. Is the context right?')
@@ -88,6 +94,7 @@ def worker(event, context):
         _maybe_call_hook(_error_handler_call_envvar, locals())
         raise
     finally:
+        logger.info('END: Handle request ID: %s', request_id)
         ### 5th hook call
         _maybe_call_hook(_post_handler_call_envvar, locals())
 

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -92,7 +92,8 @@ def attach_hooks(wait_connection=8.0, wait_job=1.0):
     - After broker connected, shutdown if cannot receive a job within 'wait_job'
       This safeguards against empty queues too.
     - Receiving a job, clears the watchdogs.
-    - Finished a job, shutdown its worker.
+    - Finished a job, set an alarm for shutdown, allowing Task to acknowledge()
+    - If a new task comes after the 1st processed, reject and shutdown.
     """
     logger.info('Attaching Celery hooks')
     logger.debug('Wait connection time: %.2f', wait_connection)
@@ -124,6 +125,7 @@ def attach_hooks(wait_connection=8.0, wait_job=1.0):
         logger.debug('Connected to the broker! [worker_ready]')
 
         worker.__task_received = False
+        worker.__task_finished = False
         def _maybe_shutdown(*args, **kwargs):
             if worker.__task_received:
                 logger.debug('Keep going. Task received [callback:worker_ready]')
@@ -136,10 +138,17 @@ def attach_hooks(wait_connection=8.0, wait_job=1.0):
     def _unset_watchdogs(*args, **kwargs):
         # Worker is not received on this signal, direct or indirectly :/
         worker = context['worker']
+
+        # New task should be rejected and returned if one was already processed.
+        worker.consumer.connection._default_channel.do_restore = True
+
         worker.__task_received = True
         logger.info('Task received! [task_prerun]')
-        worker.__task_finished = False
         cancel_wakeme()
+
+        if worker.__task_finished:  # Already worked one task? Reject and Shutdown!
+            logger.info('Rejecting a task and shutting down via WorkerShutdown() [task_prerun]')
+            raise WorkerShutdown()
 
     @task_postrun.connect  # Task finished
     def _demand_shutdown(*args, **kwargs):
@@ -153,7 +162,15 @@ def attach_hooks(wait_connection=8.0, wait_job=1.0):
         # See: https://github.com/celery/celery/issues/4002#issuecomment-377111157
         # See: https://gist.github.com/lovemyliwu/af5112de25b594205a76c3bfd00b9340
         worker.consumer.connection._default_channel.do_restore = False
-        raise WorkerShutdown()
+
+        # Raising WorkerShutdown directly does not allow the worked task to be
+        # acknowledge()ed property, leading to duplicate runs. Solved by
+        # allowing the task to finish properly and raising a WorkerShutdown()
+        # after wait_job seconds or on @task_prerun, whatever comes first.
+        def _should_shutdown(*args, **kwargs):
+            logger.info('Shutting down via WorkerShutdown() [callback:task_postrun]')
+            raise WorkerShutdown()
+        return wakeme_soon(delay=wait_job, callback=_should_shutdown)
 
     # Using weak references. Is up to the caller to store the callbacks produced
     return [_set_broker_watchdog, _set_job_watchdog, _unset_watchdogs, _demand_shutdown]

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -31,6 +31,7 @@ def spawn_worker(softlimit:'seconds'=None, hardlimit:'seconds'=None, **options):
         '--without-mingle',
         '--task-events',
         '-O', 'fair',
+        '-P', 'solo',
     ]
 
     if softlimit:

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -6,10 +6,16 @@ from functools import partial
 
 import celery.bin.celery
 import celery.worker.state
-from celery.signals import celeryd_init, worker_ready
+from celery.signals import celeryd_init, worker_ready, worker_process_shutdown, task_unknown, task_rejected
+from celery.signals import *
+from celery.exceptions import WorkerShutdown
 
 logger = logging.getLogger(__name__)
 logger.setLevel('DEBUG')
+
+# To store the Worker instance.
+# Sometime it will change to a Thread or Async aware thing
+context = {}
 
 
 def _get_options_from_environ():
@@ -62,18 +68,11 @@ def spawn_worker(softlimit:'seconds'=None, hardlimit:'seconds'=None, **options):
     raise RuntimeError('Is the worker left running?')
 
 
-def shutdown_when_done(*args, **kwargs):
-    # Start to shutdown by triggering <Ctrl+C>
-    # The worker will stop getting tasks and will prepare to shutdown
-    # but will wait the existing task to finish its lifetime.
-    reason = kwargs.get('reason', '')
-    logger.debug('Informing the workers to stop accepting tasks. %s', reason)
-    pid = os.getpid()
-    os.kill(pid, signal.SIGINT)  # Trigger Ctrl+C behaviours
-
-
 def wakeme_soon(callback:'callable'=None, delay:'seconds'=1.0, reason='', *args, **kwargs):
-    # After born, wait some seconds and get a UNIX signal poke.
+    """
+    Sets an alarm via Unix SIGALRM up to 'seconds' ahead.
+    Then calls the 'callback'.
+    """
     if reason:
         reason = 'waiting for "%s"' % reason
     logger.debug('Registering an ALRM for %.2f seconds ahead %s', delay, reason)
@@ -81,22 +80,84 @@ def wakeme_soon(callback:'callable'=None, delay:'seconds'=1.0, reason='', *args,
     signal.setitimer(signal.ITIMER_REAL, delay)
 
 
-def attach_hooks(wait_connection=4.0, wait_job=1.0):
+def cancel_wakeme():
+    """Disables the actual Unix SIGALRM set, if any"""
+    signal.signal(signal.SIGALRM, signal.SIG_DFL)   # Play safe
+    signal.setitimer(signal.ITIMER_REAL, 0)  # Disables the timer
+
+
+def attach_hooks(wait_connection=8.0, wait_job=1.0):
     """
     Register the needed hooks:
-    - One to trigger stop getting tasks after the 1st, and shutdown when done
+    - At start, shutdown if cannot get a Broker within 'wait_connection' seconds
+    - After broker connected, shutdown if cannot receive a job within 'wait_job'
+      This safeguards against empty queues too.
+    - Receiving a job, clears the watchdogs.
+    - Finished a job, shutdown its worker.
     """
     logger.info('Attaching Celery hooks')
     logger.debug('Wait connection time: %.2f', wait_connection)
     logger.debug('Wait job time: %.2f', wait_job)
 
     @celeryd_init.connect  # After worker process up
-    def _broker_connection_timeout(*args, **kwargs):
-        _shutdown = partial(shutdown_when_done, reason='Broker never connected')
-        return wakeme_soon(reason='broker connection', delay=wait_connection, callback=_shutdown)
+    def _set_broker_watchdog(conf=None, instance=None, *args, **kwargs):
+        logger.debug('Connecting to the broker [celeryd_init]')
+        context['worker'] = worker = instance
+
+        worker.__broker_connected = False
+        def _maybe_shutdown(*args, **kwargs):
+            import ipdb; ipdb.set_trace()
+            if worker.__broker_connected:
+                logger.debug('Keep going. Connected to the broker [callback:celeryd_init]')
+            else:
+                logger.info('Shutting down. Never connected to the broker [callback:celeryd_init]')
+                raise WorkerShutdown()
+        return wakeme_soon(delay=wait_connection, callback=_maybe_shutdown)
+
+    # #######
+    # @worker_init.connect  # Before connecting, if -P solo
+    # def _worker_init(sender=None, *args, **kwargs):
+    #     logger.debug('Connecting to the broker [worker_init]')
+    # #######
 
     @worker_ready.connect  # After broker queue connected
-    def _worker_ready_timeout(*args, **kwargs):
-        return wakeme_soon(reason='job to come', delay=wait_job, callback=shutdown_when_done)
+    def _set_job_watchdog(sender=None, *args, **kwargs):
+        assert context['worker'] == sender.controller, 'Oops: Are the CONTEXT messed?'
+        worker = context['worker']
+        worker.__broker_connected = True
+        logger.debug('Connected to the broker! [worker_ready]')
 
-    return [_broker_connection_timeout, _worker_ready_timeout]  # Using weak references
+        worker.__task_received = False
+        def _maybe_shutdown(*args, **kwargs):
+            if worker.__task_received:
+                logger.debug('Keep going. Task received [callback:worker_ready]')
+            else:
+                logger.info('Shutting down. Never received a Task [callback:worker_ready]')
+                # raise WorkerShutdown()
+        return wakeme_soon(delay=wait_job, callback=_maybe_shutdown)
+
+    @task_prerun.connect  # Task already got.
+    def _unset_watchdogs(*args, **kwargs):
+        # Worker is not received on this signal, direct or indirectly :/
+        worker = context['worker']
+        worker.__task_received = True
+        logger.info('Task received! [task_prerun]')
+        worker.__task_finished = False
+        cancel_wakeme()
+
+    @task_postrun.connect  # Task finished
+    def _demand_shutdown(*args, **kwargs):
+        worker = context['worker']
+        worker.__task_finished = True
+        logger.info('Job done. Now shutdown! [task_postrun]')
+
+        # Hack around "Worker shutdown creates duplicate messages in SQS broker"
+        # (applies to any broker, if I understand correctly)
+        # Celery issue #4002
+        # See: https://github.com/celery/celery/issues/4002#issuecomment-377111157
+        # See: https://gist.github.com/lovemyliwu/af5112de25b594205a76c3bfd00b9340
+        worker.consumer.connection._default_channel.do_restore = False
+        raise WorkerShutdown()
+
+    # Using weak references. Is up to the caller to store the callbacks produced
+    return [_setup_broker_watchdog, _set_job_watchdog, _unset_watchdogs, _demand_shutdown]


### PR DESCRIPTION
- Created from https://stackoverflow.com/q/49348851/798575 question
- But used https://gist.github.com/lovemyliwu/af5112de25b594205a76c3bfd00b9340
- to fix the "double execution" explained in https://github.com/celery/celery/issues/4002#issuecomment-377111157 and on the StackOverflow question
