### PR TITLE
Extras: easier Web Debugger (WDB) support

### DIFF
--- a/celery_serverless/extras/__init__.py
+++ b/celery_serverless/extras/__init__.py
@@ -53,6 +53,7 @@ def discover_wdb():
             raise RuntimeError("Could not import 'wdb'. Have you installed the the ['wdb'] extra?")
         from celery_serverless.extras.wdb import init_wdb
         return {'wdb': init_wdb()}
+    return {}
 
 
 DISCOVER_FUNCTIONS = [discover_sentry, discover_logdrain, discover_wdb]

--- a/celery_serverless/extras/__init__.py
+++ b/celery_serverless/extras/__init__.py
@@ -36,16 +36,9 @@ def discover_wdb():
     WDB_SOCKET_SERVER = os.environ.get('WDB_SOCKET_SERVER')
     WDB_SOCKET_PORT = os.environ.get('WDB_SOCKET_PORT')
     WDB_SOCKET_URL = os.environ.get('WDB_SOCKET_URL')
-    if WDB_SOCKET_URL:
-        try:
-            WDB_SOCKET_URL, WDB_SOCKET_PORT = WDB_SOCKET_URL.rsplit(':')
-        except ValueError as err:
-            msg = str(err) + '. WDB_SOCKET_SERVER format should be "tcp://hostname:port"'
-            raise ValueError(msg) from err
-        WDB_SOCKET_URL = os.environ.setdefault('WDB_SOCKET_URL', WDB_SOCKET_URL)
-        WDB_SOCKET_PORT = os.environ.setdefault('WDB_SOCKET_PORT', WDB_SOCKET_PORT)
 
-    if WDB_SOCKET_SERVER and WDB_SOCKET_PORT and not os.environ.get('CELERY_SERVERLESS_NO_WDB'):
+    needed_envs_available = bool(WDB_SOCKET_URL or (WDB_SOCKET_SERVER and WDB_SOCKET_PORT))
+    if needed_envs_available and not os.environ.get('CELERY_SERVERLESS_NO_WDB'):
         logger.info('Activating WDB (Web Debugger) extra support')
         try:
             import wdb

--- a/celery_serverless/extras/wdb.py
+++ b/celery_serverless/extras/wdb.py
@@ -33,6 +33,9 @@ def init_wdb():
         os.environ['WDB_SOCKET_PORT'],
     )
 
+    # See: https://github.com/Kozea/wdb/pull/98#issue-130738238
+    # importmagic.index spams the console on every new import. Is annoying,
+    # but on Lambdas it can cost a lot of money too.
     logger.debug("Lowering the loglevel of 'importmagic.index'")
     importmagic_logger = logging.getLogger('importmagic.index')
     importmagic_logger.setLevel('ERROR')

--- a/celery_serverless/extras/wdb.py
+++ b/celery_serverless/extras/wdb.py
@@ -1,0 +1,12 @@
+import logging
+import os
+
+from wdb import start_trace, stop_trace
+
+logger = logging.getLogger(__name__)
+
+
+def init_wdb():
+    logger.debug('Initializing WDB support envvars')
+    os.environ['WDB_NO_BROWSER_AUTO_OPEN'] = True
+    return {'start_trace': start_trace, 'stop_trace': stop_trace}

--- a/celery_serverless/extras/wdb.py
+++ b/celery_serverless/extras/wdb.py
@@ -16,6 +16,7 @@ def init_wdb():
     logger.debug('Initializing WDB support envvars')
     os.environ['WDB_NO_BROWSER_AUTO_OPEN'] = 'True'
     WDB_SOCKET_URL = os.environ.get('WDB_SOCKET_URL')
+    CELERY_SERVERLESS_BREAKPOINT = os.environ.get('CELERY_SERVERLESS_BREAKPOINT')
 
     if WDB_SOCKET_URL:
         parsed = urlparse(WDB_SOCKET_URL)
@@ -37,4 +38,4 @@ def init_wdb():
     importmagic_logger.setLevel('ERROR')
     importmagic_logger.propagate = False
 
-    return {'start_trace': start_trace, 'stop_trace': stop_trace}
+    return {'start_trace': start_trace, 'stop_trace': stop_trace, 'breakpoint': CELERY_SERVERLESS_BREAKPOINT}

--- a/celery_serverless/extras/wdb.py
+++ b/celery_serverless/extras/wdb.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from urllib.parse import urlparse
 
 from wdb import start_trace, stop_trace
 
@@ -7,6 +8,20 @@ logger = logging.getLogger(__name__)
 
 
 def init_wdb():
+    """
+    Set the environment up, if provided a WDB_SOCKET_URL in the format:
+        `tcp://serverhostname:port`
+    """
     logger.debug('Initializing WDB support envvars')
     os.environ['WDB_NO_BROWSER_AUTO_OPEN'] = True
+    WDB_SOCKET_URL = os.environ.get('WDB_SOCKET_URL')
+
+    if WDB_SOCKET_URL:
+        parsed = urlparse(WDB_SOCKET_URL)
+        if parsed.scheme.partition('+')[0] != 'tcp':
+            raise ValueError('WDB_SOCKET_URL format should be "tcp://serverhostname:port"')
+
+        os.environ.setdefault('WDB_SOCKET_SERVER', parsed.hostname)
+        os.environ.setdefault('WDB_SOCKET_PORT', parsed.port)
+
     return {'start_trace': start_trace, 'stop_trace': stop_trace}

--- a/celery_serverless/extras/wdb.py
+++ b/celery_serverless/extras/wdb.py
@@ -13,7 +13,7 @@ def init_wdb():
         `tcp://serverhostname:port`
     """
     logger.debug('Initializing WDB support envvars')
-    os.environ['WDB_NO_BROWSER_AUTO_OPEN'] = True
+    os.environ['WDB_NO_BROWSER_AUTO_OPEN'] = 'True'
     WDB_SOCKET_URL = os.environ.get('WDB_SOCKET_URL')
 
     if WDB_SOCKET_URL:
@@ -21,7 +21,12 @@ def init_wdb():
         if parsed.scheme.partition('+')[0] != 'tcp':
             raise ValueError('WDB_SOCKET_URL format should be "tcp://serverhostname:port"')
 
-        os.environ.setdefault('WDB_SOCKET_SERVER', parsed.hostname)
-        os.environ.setdefault('WDB_SOCKET_PORT', parsed.port)
+        os.environ.setdefault('WDB_SOCKET_SERVER', str(parsed.hostname or ''))
+        os.environ.setdefault('WDB_SOCKET_PORT', str(parsed.port or ''))
+
+    logger.debug("Lowering the loglevel of 'importmagic.index'")
+    importmagic_logger = logging.getLogger('importmagic.index')
+    importmagic_logger.setLevel('ERROR')
+    importmagic_logger.propagate = False
 
     return {'start_trace': start_trace, 'stop_trace': stop_trace}

--- a/celery_serverless/extras/wdb.py
+++ b/celery_serverless/extras/wdb.py
@@ -2,6 +2,7 @@ import logging
 import os
 from urllib.parse import urlparse
 
+import wdb
 from wdb import start_trace, stop_trace
 
 logger = logging.getLogger(__name__)
@@ -21,8 +22,9 @@ def init_wdb():
         if parsed.scheme.partition('+')[0] != 'tcp':
             raise ValueError('WDB_SOCKET_URL format should be "tcp://serverhostname:port"')
 
-        os.environ.setdefault('WDB_SOCKET_SERVER', str(parsed.hostname or ''))
-        os.environ.setdefault('WDB_SOCKET_PORT', str(parsed.port or ''))
+        # I should not need to do it. Anyway is how it works...
+        wdb.SOCKET_SERVER = os.environ.setdefault('WDB_SOCKET_SERVER', str(parsed.hostname or ''))
+        wdb.SOCKET_PORT = int(os.environ.setdefault('WDB_SOCKET_PORT', str(parsed.port or '')))
 
     logger.debug(
         'Using WDB_SOCKET_SERVER=%s WDB_SOCKET_PORT=%s',

--- a/celery_serverless/extras/wdb.py
+++ b/celery_serverless/extras/wdb.py
@@ -24,6 +24,12 @@ def init_wdb():
         os.environ.setdefault('WDB_SOCKET_SERVER', str(parsed.hostname or ''))
         os.environ.setdefault('WDB_SOCKET_PORT', str(parsed.port or ''))
 
+    logger.debug(
+        'Using WDB_SOCKET_SERVER=%s WDB_SOCKET_PORT=%s',
+        os.environ['WDB_SOCKET_SERVER'],
+        os.environ['WDB_SOCKET_PORT'],
+    )
+
     logger.debug("Lowering the loglevel of 'importmagic.index'")
     importmagic_logger = logging.getLogger('importmagic.index')
     importmagic_logger.setLevel('ERROR')

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -64,9 +64,11 @@ def worker(event, context):
     request_id = '(unknown)'
     if 'wdb' in available_extras:
         available_extras['wdb']['start_trace']()
+        # Will be True if CELERY_SERVERLESS_BREAKPOINT is defined.
+        # It is the preferred way to force a breakpoint.
         if available_extras['wdb']['breakpoint']:
             import wdb
-            wdb.set_trace()
+            wdb.set_trace()  # Tip: you may want to step into spawn_worker() near line 100 ;)
 
     try:
         ### 4th hook call
@@ -93,6 +95,8 @@ def worker(event, context):
         else:
             logger.debug('Old Celery worker. Already have hooks.')
 
+        # The Celery worker will start here. Will connect, take 1 (one) task,
+        # process it, and quit.
         logger.debug('Spawning the worker(s)')
         spawn_worker(
             softlimit=softlimit if softlimit > 5 else None,

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -62,6 +62,9 @@ def worker(event, context):
     global hooks
 
     request_id = '(unknown)'
+    if 'wdb' in available_extras:
+        available_extras['wdb']['start_trace']()
+
     try:
         ### 4th hook call
         _maybe_call_hook(_pre_handler_call_envvar, locals())
@@ -111,6 +114,9 @@ def worker(event, context):
         logger.info('END: Handle request ID: %s', request_id)
         ### 5th hook call
         _maybe_call_hook(_post_handler_call_envvar, locals())
+
+        if 'wdb' in available_extras:
+            available_extras['wdb']['stop_trace']()
 
 
 if 'sentry' in available_extras:

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -102,7 +102,7 @@ def worker(event, context):
     except Exception as e:
         if 'sentry' in available_extras:
             logger.warning('Sending exception collected to Sentry client')
-            available_extras['sentry'].capture_exception()
+            available_extras['sentry'].captureException()
 
         ### Err hook call
         _maybe_call_hook(_error_handler_call_envvar, locals())

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -64,6 +64,9 @@ def worker(event, context):
     request_id = '(unknown)'
     if 'wdb' in available_extras:
         available_extras['wdb']['start_trace']()
+        if available_extras['wdb']['breakpoint']:
+            import wdb
+            wdb.set_trace()
 
     try:
         ### 4th hook call

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ setup(
             'boto3>=1.7.0',
             'aioboto3>=3.0.0',
         ],
+        'wdb': [
+            'wdb>=3.2.1',
+        ],
     },
     license="Apache Software License 2.0",
     long_description=readme,


### PR DESCRIPTION
This easies the usage of a debugger on the AWS Lambda, limited to the function runtime.

You should open a `wdb.server.py` server and provide its entrypoint via `WDB_SOCKET_URL=tcp://0.tcp.ngrok.io:00000` (mine uses Ngrok to expose the service to AWS)

On errors, it will stop and wait you to connect and go step by step.

Provide `CELERY_SERVERLESS_BREAKPOINT` envvar and it will `wdb.set_trace()` before the event processing.

Caveats:
* It will not open your browser on breakpoint. You need to keep an eye on `localhost:1987` page for incoming connections.