### PR TITLE
Extras: s3conf support

### DIFF
--- a/celery_serverless/extras/__init__.py
+++ b/celery_serverless/extras/__init__.py
@@ -68,14 +68,17 @@ def discover_s3conf():
 
 
 DISCOVER_FUNCTIONS = [
+    discover_s3conf,
     discover_sentry,
     discover_logdrain,
     discover_wdb,
-    discover_s3conf,
 ]
 
 def discover_extras():
+    _s3conf_extra = available_extras.pop('s3conf', {})
     available_extras.clear()
     for func in DISCOVER_FUNCTIONS:
+        if func is discover_s3conf and _s3conf_extra:
+            func = lambda: _s3conf_extra
         available_extras.update(func())
     return available_extras

--- a/celery_serverless/extras/__init__.py
+++ b/celery_serverless/extras/__init__.py
@@ -49,6 +49,24 @@ def discover_wdb():
     return {}
 
 
+def discover_s3conf():
+    ## S3Conf extras:
+    S3CONF = os.environ.get('S3CONF')
+    if S3CONF and not os.environ.get('CELERY_SERVERLESS_NO_S3CONF'):
+        logger.info('Activating S3CONF extra support')
+        try:
+            import s3conf
+        except ImportError:
+            raise RuntimeError("Could not import 's3conf'. Have you installed the the ['s3conf'] extra?")
+        from celery_serverless.extras.s3conf import init_s3conf
+        return {
+            's3conf': {
+                'apply':init_s3conf,
+            }
+        }
+    return {}
+
+
 DISCOVER_FUNCTIONS = [discover_sentry, discover_logdrain, discover_wdb]
 
 def discover_extras():

--- a/celery_serverless/extras/__init__.py
+++ b/celery_serverless/extras/__init__.py
@@ -67,7 +67,7 @@ def discover_s3conf():
     return {}
 
 
-DISCOVER_FUNCTIONS = [discover_sentry, discover_logdrain, discover_wdb]
+DISCOVER_FUNCTIONS = [discover_sentry, discover_logdrain, discover_wdb, discover_s3conf]
 
 def discover_extras():
     available_extras.clear()

--- a/celery_serverless/extras/__init__.py
+++ b/celery_serverless/extras/__init__.py
@@ -67,7 +67,12 @@ def discover_s3conf():
     return {}
 
 
-DISCOVER_FUNCTIONS = [discover_sentry, discover_logdrain, discover_wdb, discover_s3conf]
+DISCOVER_FUNCTIONS = [
+    discover_sentry,
+    discover_logdrain,
+    discover_wdb,
+    discover_s3conf,
+]
 
 def discover_extras():
     available_extras.clear()

--- a/celery_serverless/extras/s3conf.py
+++ b/celery_serverless/extras/s3conf.py
@@ -1,0 +1,28 @@
+import logging
+import os
+
+from s3conf.s3conf import S3Conf
+
+logger = logging.getLogger(__name__)
+
+
+def init_s3conf():
+    """
+    Set the environment up, if provided a S3CONF in the format:
+        `s3://bucketname/filepath/with/folders/envfile.env`
+    """
+    logger.debug('Initializing S3CONF environment')
+    conf = S3Conf()
+    external_environ = conf.get_envfile().as_dict()
+    os.environ.update(external_environ)
+
+    S3CONF_MAP = os.environ.get('S3CONF_MAP')
+    if S3CONF_MAP:
+        logger.debug('Fetching S3CONF_MAP environment files')
+        conf.downsync(S3CONF_MAP)
+
+    return {
+        'client': conf,
+        'external_environ': external_environ,
+        's3conf_map': S3CONF_MAP,
+    }

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -49,6 +49,10 @@ from celery_serverless.extras import discover_extras
 available_extras = discover_extras()
 print('Available extras:', list(available_extras.keys()), file=sys.stderr)
 
+if 's3conf' in available_extras:
+    logger.debug('Applying S3CONF serverless environment extra')
+    available_extras.update(available_extras['s3conf']['apply']())
+
 import json
 from celery_serverless.worker_management import spawn_worker, attach_hooks
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ setup(
         'wdb': [
             'wdb>=3.2.1',
         ],
+        's3conf': [
+            's3conf>=0.6.0',
+        ],
     },
     license="Apache Software License 2.0",
     long_description=readme,


### PR DESCRIPTION
Applies the s3conf environment from `S3CONF` envvar if available.

As always, this extra can be suppressed by defining a `CELERY_SERVERLESS_NO_S3CONF` envvar.

The extra is a bit convoluted because:
1. Should be applied before the others, as the needed envvars can came from s3conf
1. Costs a lot more time than the others, then some effort is put to reuse the past results if `discover_extras()` is called multiple times.