### PR TITLE
Watch forever by reinvoking another watchdog when near the Lambda timeout

### DIFF
--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -119,4 +119,4 @@ def watchdog(event, context):
         "message": "Watchdog woke, worked, and rested.",
         "fulfilled": fulfilled,
     }
-    return {"statusCode": 200, "body": json.dumps(body)}
+    return {"statusCode": 200 if fulfilled else 202, "body": json.dumps(body)}

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -110,7 +110,9 @@ def watchdog(event, context):
             time.sleep(1)  # Let distributed locks to propagate
 
         logger.info('All set. Reinvoking the Watchdog')
-        invoke_watchdog()
+        _, future = invoke_watchdog()
+        future.result()
+        logger.info('Done reinvoking another Watchdog')
 
     logger.debug('Cleaning up before exit')
     body = {

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -17,7 +17,8 @@ if os.environ.get('CELERY_SERVERLESS_LOGLEVEL'):
 print('Celery serverless loglevel:', logger.getEffectiveLevel())
 
 from redlock import RedLock
-from celery_serverless.watchdog import Watchdog, KombuQueueLengther, build_intercom
+from timeoutcontext import timeout as timeout_context
+from celery_serverless.watchdog import Watchdog, KombuQueueLengther, build_intercom, invoke_watchdog
 from celery_serverless.worker_management import spawn_worker, attach_hooks
 hooks = []
 
@@ -82,10 +83,27 @@ def watchdog(event, context):
     else:
         watched = KombuQueueLengther(queue_url, 'celery')   # TODO: Allow queue name to be chosen
 
-    Watchdog(communicator=build_intercom(intercom_url), name=lock_name, lock=lock, watched=watched).monitor()
+    watchdog = Watchdog(communicator=build_intercom(intercom_url), name=lock_name, lock=lock, watched=watched)
+
+    try:
+        remaining_seconds = context.get_remaining_time_in_millis() / 1000.0
+    except Exception as e:
+        logger.exception('Could not got remaining_seconds. Is the context right?')
+        remaining_seconds = 5 * 60 # 5 minutes by default
+
+    spare_time = 30  # Should be enough time to retrigger this FaaS again
+    fulfilled = False
+    try:
+        with timeout_context(remaining_seconds-spare_time):
+            watchdog.monitor()
+            fulfilled = True
+    except TimeoutError:
+        logger.info('Still stuff to monitor but this Function is out of time. Reinvoking the Watchdog!')
+        invoke_watchdog()
 
     logger.debug('Cleaning up before exit')
     body = {
         "message": "Watchdog woke, worked, and rested.",
+        "fulfilled": fulfilled,
     }
     return {"statusCode": 200, "body": json.dumps(body)}

--- a/celery_serverless/invoker.py
+++ b/celery_serverless/invoker.py
@@ -219,3 +219,7 @@ def invoke(target='watchdog', config=None, *args, **kwargs):
 
 def invoke_worker(config=None, data=None, *args, **kwargs):
     return invoke(target='worker', extra_data=data or {}, *args, **kwargs)
+
+
+def invoke_watchdog(config=None, data=None, *args, **kwargs):
+    return invoke(target='watchdog', extra_data=data or {}, *args, **kwargs)

--- a/celery_serverless/watchdog.py
+++ b/celery_serverless/watchdog.py
@@ -13,7 +13,7 @@ import backoff
 from redis import StrictRedis
 from kombu import Connection
 from kombu.transport import pyamqp
-from celery_serverless.invoker import invoke_worker
+from celery_serverless.invoker import invoke_worker, invoke_watchdog
 
 logger = logging.getLogger(__name__)
 logger.setLevel('DEBUG')

--- a/celery_serverless/watchdog.py
+++ b/celery_serverless/watchdog.py
@@ -204,7 +204,7 @@ def inform_worker_new(redis:'StrictRedis', worker_id:str, prefix=DEFAULT_BASENAM
         return None
 
     worker_prefix = _get_worker_key_prefix(prefix=prefix)
-    worker_key = worker_prefix + worker_id
+    worker_key = worker_prefix + str(worker_id)
     workers_started_key = _get_workers_started_key(prefix=prefix)
 
     metadata = {
@@ -232,7 +232,7 @@ def inform_worker_busy(redis:'StrictRedis', worker_id:str, prefix=DEFAULT_BASENA
     workers_started_key = _get_workers_started_key(prefix=prefix)
     workers_busy_key = _get_workers_busy_key(prefix=prefix)
     worker_prefix = _get_worker_key_prefix(prefix=prefix)
-    worker_key = worker_prefix + worker_id
+    worker_key = worker_prefix + str(worker_id)
     epoch_now = datetime.now(timezone.utc).timestamp()  # secs from epoch
 
     with redis.pipeline() as pipe:
@@ -256,7 +256,7 @@ def inform_worker_leave(redis:'StrictRedis', worker_id:str, prefix=DEFAULT_BASEN
     workers_started_key = _get_workers_started_key(prefix=prefix)
     workers_busy_key = _get_workers_busy_key(prefix=prefix)
     worker_prefix = _get_worker_key_prefix(prefix=prefix)
-    worker_key = worker_prefix + worker_id
+    worker_key = worker_prefix + str(worker_id)
 
     with redis.pipeline() as pipe:
         pipe.delete(worker_key)  # TODO: Use "UNLINK" instead of "DEL"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ future-thread~=1.0
 backoff~=1.5
 redlock~=1.2.0
 dirtyjson~=1.0.7
+timeoutcontext==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ requirements = [
     'future-thread~=1.0',
     'backoff>=1.5.0',
     'redlock>=1.2.0',
+    'timeoutcontext>=1.2.0',
 ]
 
 setup_requirements = []


### PR DESCRIPTION
Use a timeout context manager (implemented via SIGALRM) to unlock and reinvoke another Watchdog if there is still work to do. This way, it can keep regenerating itself until is time to stop.

The soft timeout is set to 30sec before the Lambda timeout. Should be plenty of time to invoke another lambda. This 30sec is not configurable now, but is easy to do it in the future.

Thoughts about using an internal timeout instead of a SIGALRM one to be less intrusive, but SIGALRM is safer: any loop delay misconfigured could block for too much time and this can prevent he reinvocation of another Watchdog.