### PR TITLE
Fix watchdog - (Better logs; Lock fixes; Metadata fixes)

### DIFF
--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -40,6 +40,8 @@ def worker(event, context, intercom_url=None):
     softlimit = remaining_seconds-30.0  # Poke the job 30sec before the abyss
     hardlimit = remaining_seconds-15.0  # Kill the job 15sec before the abyss
 
+    logger.debug('Event: %s', event)
+
     if not hooks:
         logger.debug('Fresh Celery worker. Attach hooks!')
         hooks = attach_hooks(intercom_url=intercom_url, worker_metadata=event or {})

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -22,7 +22,7 @@ from redis.lock import LockError
 from timeoutcontext import timeout as timeout_context
 from celery_serverless.invoker import invoke_watchdog
 from celery_serverless.watchdog import Watchdog, KombuQueueLengther, build_intercom, get_watchdog_lock
-from celery_serverless.worker_management import spawn_worker, attach_hooks
+from celery_serverless.worker_management import spawn_worker, attach_hooks, set_worker_metadata
 hooks = []
 
 
@@ -42,9 +42,11 @@ def worker(event, context, intercom_url=None):
 
     logger.debug('Event: %s', event)
 
+    set_worker_metadata(intercom_url=intercom_url, worker_metadata=event or {})
+
     if not hooks:
         logger.debug('Fresh Celery worker. Attach hooks!')
-        hooks = attach_hooks(intercom_url=intercom_url, worker_metadata=event or {})
+        hooks = attach_hooks()
     else:
         logger.debug('Old Celery worker. Already have hooks.')
 

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -18,6 +18,7 @@ if os.environ.get('CELERY_SERVERLESS_LOGLEVEL'):
 print('Celery serverless loglevel:', logger.getEffectiveLevel())
 
 from redis import StrictRedis
+from redis.lock import LockError
 from timeoutcontext import timeout as timeout_context
 from celery_serverless.invoker import invoke_watchdog
 from celery_serverless.watchdog import Watchdog, KombuQueueLengther, build_intercom, get_watchdog_lock
@@ -96,7 +97,7 @@ def watchdog(event, context):
         # Be sure that the lock is released. Then reinvoke.
         try:
             lock.release()
-        except (RuntimeError, AttributeError):
+        except (RuntimeError, AttributeError, LockError):
             pass
 
         logger.info('All set. Reinvoking the Watchdog')

--- a/celery_serverless/invoker.py
+++ b/celery_serverless/invoker.py
@@ -36,8 +36,8 @@ from .utils import run_aio_on_thread, get_client_lock
 
 
 CELERY_HANDLER_PATHS = {
-    'worker': 'celery_serverless.handler_worker',
-    'watchdog': 'celery_serverless.handler_watchdog',
+    'worker': 'celery_serverless_handler.handler_worker',
+    'watchdog': 'celery_serverless_handler.handler_watchdog',
 }
 
 

--- a/celery_serverless/watchdog.py
+++ b/celery_serverless/watchdog.py
@@ -247,12 +247,12 @@ def inform_worker_busy(redis:'StrictRedis', worker_id:str, prefix=DEFAULT_BASENA
         pipe.expire(worker_key, DEFAULT_WORKER_EXPIRE)
         pipe.expire(workers_busy_key, DEFAULT_WORKER_EXPIRE)
         pipe.expire(workers_started_key, DEFAULT_WORKER_EXPIRE)
-        result, *_ = pipe.execute()
+        result_add, result_rem, *_ = pipe.execute()
 
     logger.info('Informed [busy]: %s', worker_key)
-    logger.debug('ZADD %s: %s', workers_busy_key, result[0])
-    logger.debug('ZREM %s: %s', workers_started_key, result[1])
-    return result
+    logger.debug('ZADD %s: %s', workers_busy_key, result_add)
+    logger.debug('ZREM %s: %s', workers_started_key, result_rem)
+    return result_add
 
 
 def inform_worker_leave(redis:'StrictRedis', worker_id:str, prefix=DEFAULT_BASENAME):

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -140,6 +140,8 @@ def attach_hooks(wait_connection=8.0, wait_job=4.0, intercom_url='', worker_meta
         'prefix': worker_metadata['prefix'],
     }
 
+    logger.debug("Event -> context[worker_watchdog]: %s", context['worker_watchdog'])
+
     @celeryd_init.connect  # After worker process up
     def _set_broker_watchdog(conf=None, instance=None, *args, **kwargs):
         logger.debug('Connecting to the broker [celeryd_init]')

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -112,7 +112,25 @@ def _shutdown_worker(context):
     raise WorkerShutdown()
 
 
-def attach_hooks(wait_connection=8.0, wait_job=4.0, intercom_url='', worker_metadata=None):
+def set_worker_metadata(intercom_url='', worker_metadata=None):
+    intercom_url = intercom_url or os.environ.get('CELERY_SERVERLESS_INTERCOM_URL')
+    assert intercom_url, 'The CELERY_SERVERLESS_INTERCOM_URL envvar should be set. Even to "disabled" to disable it.'
+
+    worker_metadata = worker_metadata or {
+        'worker_id': uuid.uuid1(),
+        'prefix': '(undefined)',
+    }
+
+    context['worker_watchdog'] = {
+        'intercom': watchdog.build_intercom(intercom_url),
+        'worker_metadata': worker_metadata,
+        'worker_id': worker_metadata['worker_id'],
+        'prefix': worker_metadata['prefix'],
+    }
+    logger.debug("Event -> context[worker_watchdog]: %s", context['worker_watchdog'])
+
+
+def attach_hooks(wait_connection=8.0, wait_job=4.0):
     """
     Register the needed hooks:
     - At start, shutdown if cannot get a Broker within 'wait_connection' seconds
@@ -125,22 +143,6 @@ def attach_hooks(wait_connection=8.0, wait_job=4.0, intercom_url='', worker_meta
     logger.info('Attaching Celery hooks')
     logger.debug('Wait connection time: %.2f', wait_connection)
     logger.debug('Wait job time: %.2f', wait_job)
-
-    intercom_url = intercom_url or os.environ.get('CELERY_SERVERLESS_INTERCOM_URL')
-    worker_metadata = worker_metadata or {
-        'worker_id': uuid.uuid1(),
-        'prefix': '(undefined)',
-    }
-    assert intercom_url, 'The CELERY_SERVERLESS_INTERCOM_URL envvar should be set. Even to "disabled" to disable it.'
-
-    context['worker_watchdog'] = {
-        'intercom': watchdog.build_intercom(intercom_url),
-        'worker_metadata': worker_metadata,
-        'worker_id': worker_metadata['worker_id'],
-        'prefix': worker_metadata['prefix'],
-    }
-
-    logger.debug("Event -> context[worker_watchdog]: %s", context['worker_watchdog'])
 
     @celeryd_init.connect  # After worker process up
     def _set_broker_watchdog(conf=None, instance=None, *args, **kwargs):

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -73,6 +73,7 @@ def spawn_worker(softlimit:'seconds'=None, hardlimit:'seconds'=None, **options):
     try:
         celery.bin.celery.main(command_argv)  # Will block until worker dies.
     except SystemExit as e:  # Worker is dead.
+        logger.debug('Caught a SystemExit.')
         state = celery.worker.state
         state.should_stop = False
         state.should_terminate = False


### PR DESCRIPTION
- Metadata origin and regeneration fixes: Now it regenerates on every new event, not on the 1st only
- More logs about state changes, as the state is stored on Redis with a Event-provided key
- Handle lock/unlock errors when using Redis locks.
- Renamed the handler locations to ease serverless invocation gimmicks

(closing #23, in favor of this one)