### PR TITLE
Refactor: spawn_worker() - > WorkerRunner

### DIFF
--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -24,8 +24,6 @@ from celery_serverless.invoker import invoke_watchdog
 from celery_serverless.watchdog import Watchdog, KombuQueueLengther, build_intercom, get_watchdog_lock
 from celery_serverless.worker_management import WorkerRunner, remaining_lifetime_getter
 
-_worker_runner = WorkerRunner()
-
 
 @handler_wrapper
 def worker(event, context, intercom_url=None):
@@ -34,6 +32,8 @@ def worker(event, context, intercom_url=None):
     logger.debug('Event: %s', event)
 
     lifetime_generator = remaining_lifetime_getter(context)
+
+    _worker_runner = WorkerRunner()
     _worker_runner.lifetime_getter = lambda: next(lifetime_generator)
     _worker_runner.set_worker_metadata(intercom_url=intercom_url, worker_metadata=event or {})
 

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -28,20 +28,9 @@ from celery_serverless.worker_management import WorkerRunner, remaining_lifetime
 @handler_wrapper
 def worker(event, context, intercom_url=None):
     event = event or {}
-
     logger.debug('Event: %s', event)
 
-    lifetime_generator = remaining_lifetime_getter(context)
-
-    _worker_runner = WorkerRunner()
-    _worker_runner.lifetime_getter = lambda: next(lifetime_generator)
-    _worker_runner.set_worker_metadata(intercom_url=intercom_url, worker_metadata=event or {})
-
-    if not _worker_runner.hooks:
-        logger.debug('Fresh Celery worker. Attach hooks!')
-        _worker_runner.attach_hooks()
-    else:
-        logger.debug('Old Celery worker. Already have hooks.')
+    _worker_runner = WorkerRunner(intercom_url=intercom_url, lambda_context=context, worker_metadata=event)
 
     # The Celery worker will start here. Will connect, take 1 (one) task,
     # process it, and quit.

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -29,7 +29,6 @@ _worker_runner = WorkerRunner()
 
 @handler_wrapper
 def worker(event, context, intercom_url=None):
-    global hooks
     event = event or {}
 
     logger.debug('Event: %s', event)

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -33,7 +33,8 @@ def worker(event, context, intercom_url=None):
 
     logger.debug('Event: %s', event)
 
-    _worker_runner.lifetime_getter = remaining_lifetime_getter(context)
+    lifetime_generator = remaining_lifetime_getter(context)
+    _worker_runner.lifetime_getter = lambda: next(lifetime_generator)
     _worker_runner.set_worker_metadata(intercom_url=intercom_url, worker_metadata=event or {})
 
     if not _worker_runner.hooks:

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -87,7 +87,7 @@ class WorkerRunner(object):
         self._task_max_lifetime = task_max_lifetime
 
     def run_worker(self, **options):
-        remaining_seconds = next(self.lifetime_getter)
+        remaining_seconds = self.lifetime_getter()
 
         command_argv = [
             'celery',

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -107,7 +107,7 @@ class WorkerRunner(object):
             command_argv.extend(['--soft-time-limit', '%s' % softlimit])
 
         hardlimit = remaining_seconds-self._hardlimit  # Kill the job 15sec before the abyss
-        if hardlimit:  # At least 5 sec.
+        if hardlimit > 5:  # At least 5 sec.
             command_argv.extend(['--time-limit', '%s' % hardlimit])
 
         options.update(dict(_get_options_from_environ()))

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -77,6 +77,8 @@ class WorkerRunner(object):
     # To store the Worker instance.
     # Sometime it will change to a Thread or Async aware thing
     worker = None
+    hooks = None  # type: list
+    lifetime_getter = None  # type: callable
 
     def __init__(self, task_max_lifetime=300-15-30, softlimit=30, hardlimit=15):
         self._softlimit = softlimit
@@ -85,7 +87,7 @@ class WorkerRunner(object):
         self._intercom_url = os.environ.get('CELERY_SERVERLESS_INTERCOM_URL')
 
     def run_worker(self, **options):
-        remaining_seconds = next(self._lifetime_getter)
+        remaining_seconds = next(self.lifetime_getter) if self.lifetime_getter else 5*60
 
         command_argv = [
             'celery',
@@ -145,7 +147,7 @@ class WorkerRunner(object):
         """
         Will a new task fail if it uses the whole task_max_lifetime?
         """
-        return self._task_max_lifetime > self._lifetime_getter()
+        return self._task_max_lifetime > self.lifetime_getter()
 
     def set_worker_metadata(self, intercom_url='', worker_metadata=None):
         intercom_url = intercom_url or self._intercom_url

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -78,16 +78,16 @@ class WorkerRunner(object):
     # Sometime it will change to a Thread or Async aware thing
     worker = None
     hooks = None  # type: list
-    lifetime_getter = None  # type: callable
+    lifetime_getter = lambda: 5*60
+    _intercom_url = None  # type: str
 
     def __init__(self, task_max_lifetime=300-15-30, softlimit=30, hardlimit=15):
         self._softlimit = softlimit
         self._hardlimit = hardlimit
         self._task_max_lifetime = task_max_lifetime
-        self._intercom_url = os.environ.get('CELERY_SERVERLESS_INTERCOM_URL')
 
     def run_worker(self, **options):
-        remaining_seconds = next(self.lifetime_getter) if self.lifetime_getter else 5*60
+        remaining_seconds = next(self.lifetime_getter)
 
         command_argv = [
             'celery',
@@ -150,8 +150,8 @@ class WorkerRunner(object):
         return self._task_max_lifetime > self.lifetime_getter()
 
     def set_worker_metadata(self, intercom_url='', worker_metadata=None):
-        intercom_url = intercom_url or self._intercom_url
-        assert intercom_url, 'The CELERY_SERVERLESS_INTERCOM_URL envvar should be set. Even to "disabled" to disable it.'
+        self._intercom_url = intercom_url or os.environ.get('CELERY_SERVERLESS_INTERCOM_URL')
+        assert self._intercom_url, 'The CELERY_SERVERLESS_INTERCOM_URL envvar should be set. Even to "disabled" to disable it.'
 
         worker_metadata = worker_metadata or {
             'worker_id': uuid.uuid1(),

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -149,6 +149,7 @@ class WorkerRunner(object):
             watchdog_context['worker_id'],
             prefix=watchdog_context['prefix'],
         )
+        self.is_shutting_down = False
         raise WorkerShutdown()
 
     def is_time_up(self):

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -266,7 +266,7 @@ class WorkerRunner(object):
                 _set_job_watchdog()
 
         # Using weak references. Is up to the caller to clear the callbacks produced
-        self.hooks = [_set_broker_watchdog, _set_job_watchdog, _unset_watchdogs, _ack_success]
+        self.hooks = [_set_broker_watchdog, _set_job_watchdog, _unset_watchdogs, _ack_success, _consider_a_shutdown]
         return self.hooks
 
     def _demand_shutdown(self, *args, **kwargs):

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -89,6 +89,7 @@ class WorkerSpawner(object):
             'lifetime_getter': lifetime_getter,
             'task_max_lifetime': task_max_lifetime,
         }
+        self.intercom_url = os.environ.get('CELERY_SERVERLESS_INTERCOM_URL')
 
     def spawn_worker(self, **options):
         remaining_seconds = next(self.context['lifetime_getter'])
@@ -154,7 +155,7 @@ class WorkerSpawner(object):
         return self.context['task_max_lifetime'] > self.context['lifetime_getter']()
 
     def set_worker_metadata(self, intercom_url='', worker_metadata=None):
-        intercom_url = intercom_url or os.environ.get('CELERY_SERVERLESS_INTERCOM_URL')
+        intercom_url = intercom_url or self.intercom_url
         assert intercom_url, 'The CELERY_SERVERLESS_INTERCOM_URL envvar should be set. Even to "disabled" to disable it.'
 
         worker_metadata = worker_metadata or {

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -220,8 +220,10 @@ class WorkerRunner(object):
         def _set_job_watchdog(sender=None, *args, **kwargs):
             # assert context['worker'] == sender.controller, 'Oops: Are the CONTEXT messed?'
             worker = self._worker
-            worker.__broker_connected = True
-            logger.debug('Connected to the broker! [worker_ready]')
+
+            if sender:
+                worker.__broker_connected = True
+                logger.debug('Connected to the broker! [worker_ready]')
 
             worker.__task_received = False
             worker.__task_finished = False
@@ -275,7 +277,6 @@ class WorkerRunner(object):
         def _consider_a_shutdown(*args, **kwargs):
             worker = self._worker
             worker.__task_finished = True
-            logger.info('Job done. Is there time for one more? [task_postrun]')
 
             if self.is_shutting_down:
                 logger.info('No time for another job. Now shutdown! [task_postrun]')

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -73,7 +73,7 @@ def remaining_lifetime_getter(lambda_context=None) -> 'float':
         yield remaining_seconds
 
 
-class WorkerSpawner(object):
+class WorkerRunner(object):
     # To store the Worker instance.
     # Sometime it will change to a Thread or Async aware thing
     worker = None
@@ -85,7 +85,7 @@ class WorkerSpawner(object):
         self._task_max_lifetime = task_max_lifetime
         self._intercom_url = os.environ.get('CELERY_SERVERLESS_INTERCOM_URL')
 
-    def spawn_worker(self, **options):
+    def run_worker(self, **options):
         remaining_seconds = next(self._lifetime_getter)
 
         command_argv = [

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -3,7 +3,7 @@ import os
 import uuid
 import signal
 import logging
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 
 import celery.bin.celery
 import celery.worker.state
@@ -59,7 +59,7 @@ def remaining_lifetime_getter(lambda_context=None) -> 'float':
     Generates the remaining lifetime of this Lambda in seconds,
     given a 'lambda_context'
     """
-    starting_time = datetime.now()
+    starting_time = datetime.now(timezone.utc)
     try:
         initial_remaining_millis = lambda_context.get_remaining_time_in_millis()
     except Exception as e:
@@ -75,7 +75,7 @@ def remaining_lifetime_getter(lambda_context=None) -> 'float':
     )
 
     while True:
-        remaining_seconds = (ending_time - datetime.now()).total_seconds()
+        remaining_seconds = (ending_time - datetime.now(timezone.utc)).total_seconds()
         logger.info('Remaining time calculated: %s sec.', remaining_seconds)
         yield remaining_seconds
 

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -65,10 +65,17 @@ def remaining_lifetime_getter(lambda_context=None) -> 'float':
     except Exception as e:
         logger.exception('Could not get remaining_seconds. Is the context right?')
         initial_remaining_millis = 5 * 60 * 1000 # 5 minutes by default
+    logger.debug('Initial remaining time: %s ms.', initial_remaining_millis)
+
     ending_time = starting_time + timedelta(milliseconds=initial_remaining_millis)
+    logger.debug(
+        'Ending time: %s (starting + delta -> %s + %s)',
+        ending_time, starting_time,
+        timedelta(milliseconds=initial_remaining_millis).total_seconds()
+    )
 
     while True:
-        remaining_seconds = (ending_time - datetime.now()).seconds
+        remaining_seconds = (ending_time - datetime.now()).total_seconds()
         logger.info('Remaining time calculated: %s sec.', remaining_seconds)
         yield remaining_seconds
 

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -78,10 +78,9 @@ class WorkerRunner(object):
     # Sometime it will change to a Thread or Async aware thing
     worker = None
 
-    def __init__(self, task_max_lifetime=300-15-30, softlimit=30, hardlimit=15, lifetime_getter:'callable'=None):
+    def __init__(self, task_max_lifetime=300-15-30, softlimit=30, hardlimit=15):
         self._softlimit = softlimit
         self._hardlimit = hardlimit
-        self._lifetime_getter = lifetime_getter
         self._task_max_lifetime = task_max_lifetime
         self._intercom_url = os.environ.get('CELERY_SERVERLESS_INTERCOM_URL')
 
@@ -265,8 +264,8 @@ class WorkerRunner(object):
                 _set_job_watchdog()
 
         # Using weak references. Is up to the caller to clear the callbacks produced
-        self._hooks = [_set_broker_watchdog, _set_job_watchdog, _unset_watchdogs, _ack_success]
-        return self._hooks
+        self.hooks = [_set_broker_watchdog, _set_job_watchdog, _unset_watchdogs, _ack_success]
+        return self.hooks
 
     def _demand_shutdown(self, *args, **kwargs):
         worker = self._worker

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -3,6 +3,7 @@ import os
 import uuid
 import signal
 import logging
+from datetime import timedelta, datetime
 
 import celery.bin.celery
 import celery.worker.state
@@ -63,8 +64,6 @@ def remaining_lifetime_getter(lambda_context=None) -> 'float':
     Generates the remaining lifetime of this Lambda in seconds,
     given a 'lambda_context'
     """
-    from datetime import timedelta, datetime
-
     starting_time = datetime.now()
     try:
         initial_remaining_millis = lambda_context.get_remaining_time_in_millis()

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -37,10 +37,9 @@ def _get_options_from_environ():
 
 def wakeme_soon(callback:'callable'=None, delay:'seconds'=1.0, reason='', *args, **kwargs):
     """
-    Sets an alarm via Unix SIGALRM up to 'seconds' ahead.
-    Then calls the 'callback'.
-    Only ONE alarm can exist at a time. If this function is called multiple times, only the
-    last call remains active.
+    Sets an alarm via Unix SIGALRM up to 'seconds' ahead. Then calls the 'callback'.
+    Beware that ONLY ONE alarm can exist at a time. This is how Unix works.
+    If this function is called multiple times, only the last call remains active.
     """
     if reason:
         reason = 'waiting for "%s"' % reason

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -76,7 +76,7 @@ def remaining_lifetime_getter(lambda_context=None) -> 'float':
 
     while True:
         remaining_seconds = (ending_time - datetime.now(timezone.utc)).total_seconds()
-        logger.info('Remaining time calculated: %s sec.', remaining_seconds)
+        logger.info('Remaining time calculated: %.2f sec.', remaining_seconds)
         yield remaining_seconds
 
 
@@ -88,8 +88,10 @@ class WorkerRunner(object):
         # To store the Worker instance.
         # Sometime it will change to a Thread or Async aware thing
         self.worker = None
+
+        _lifetime_generator = remaining_lifetime_getter(lambda_context)
+        self.lifetime_getter = lambda: next(_lifetime_generator)
         self.is_shutting_down = False
-        self.lifetime_getter = lambda: next(remaining_lifetime_getter(lambda_context))
 
         self._softlimit = softlimit
         self._hardlimit = hardlimit


### PR DESCRIPTION
Convert the `spawn_worker()` to a class `WorkerRunner`, incorporating the `context` global contents