### PR TITLE
Fix hooks: Should be class-wide, not linking to instances

### DIFF
--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -91,6 +91,7 @@ class WorkerRunner(object):
         self.worker = None
         WorkerRunner._current_runner = self
 
+        _lifetime_generator = remaining_lifetime_getter(lambda_context)
         self.lifetime_getter = lambda: next(_lifetime_generator)
         self.is_shutting_down = False
 

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -82,14 +82,15 @@ def remaining_lifetime_getter(lambda_context=None) -> 'float':
 
 class WorkerRunner(object):
     hooks = []
+    _current_runner = None
 
     def __init__(self, task_max_lifetime=300-15-30, softlimit=30, hardlimit=15,
                  intercom_url='', lambda_context=None, worker_metadata=None):
         # To store the Worker instance.
         # Sometime it will change to a Thread or Async aware thing
         self.worker = None
+        WorkerRunner._current_runner = self
 
-        _lifetime_generator = remaining_lifetime_getter(lambda_context)
         self.lifetime_getter = lambda: next(_lifetime_generator)
         self.is_shutting_down = False
 
@@ -115,7 +116,7 @@ class WorkerRunner(object):
 
 
     def run_worker(self, **options):
-        self.maybe_attach_hooks()
+        WorkerRunner.maybe_attach_hooks()
         remaining_seconds = self.lifetime_getter()
 
         command_argv = [
@@ -179,7 +180,8 @@ class WorkerRunner(object):
         """
         return self._task_max_lifetime > self.lifetime_getter()
 
-    def maybe_attach_hooks(self, wait_connection=8.0, wait_job=4.0):
+    @classmethod
+    def maybe_attach_hooks(cls, wait_connection=8.0, wait_job=4.0):
         """
         Register the needed hooks:
         - At start, shutdown if cannot get a Broker within 'wait_connection' seconds
@@ -189,9 +191,9 @@ class WorkerRunner(object):
         - Finished a job, set an alarm for shutdown, allowing Task to acknowledge()
         - If a new task comes after the 1st processed, reject and shutdown.
         """
-        if self.hooks:
+        if cls.hooks:
             logger.debug('Old worker instance. Already have hooks.')
-            return self.hooks
+            return cls.hooks
         logger.debug('Fresh worker instance. Attach hooks!')
 
         logger.info('Attaching Celery hooks')
@@ -200,6 +202,7 @@ class WorkerRunner(object):
 
         @celeryd_init.connect  # After worker process up
         def _set_broker_watchdog(conf=None, instance=None, *args, **kwargs):
+            self = cls._current_runner
             logger.debug('Connecting to the broker [celeryd_init]')
             self._worker = worker = instance
 
@@ -220,6 +223,7 @@ class WorkerRunner(object):
 
         @worker_ready.connect  # After broker queue connected
         def _set_job_watchdog(sender=None, *args, **kwargs):
+            self = cls._current_runner
             # assert context['worker'] == sender.controller, 'Oops: Are the CONTEXT messed?'
             worker = self._worker
 
@@ -234,6 +238,7 @@ class WorkerRunner(object):
             worker.consumer.add_task_queue('celery')  # TODO: Select the queue dynamically
 
             def _maybe_shutdown(*args, **kwargs):
+                self = cls._current_runner
                 if worker.__task_received:
                     logger.debug('Keep going. Task received [callback:worker_ready]')
                 else:
@@ -245,6 +250,7 @@ class WorkerRunner(object):
 
         @task_prerun.connect  # Task already got.
         def _unset_watchdogs(*args, **kwargs):
+            self = cls._current_runner
             # Worker is not received on this signal, direct or indirectly :/
             worker = self._worker
             worker.__task_received = True
@@ -265,6 +271,7 @@ class WorkerRunner(object):
 
         @task_success.connect
         def _ack_success(sender=None, *args, **kwargs):
+            self = cls._current_runner
             task = sender
             logger.info('Job done. Consider stop receiving new messages avoiding Kombu prefetch. [task_success]')
 
@@ -277,6 +284,7 @@ class WorkerRunner(object):
 
         @task_postrun.connect  # Task finished
         def _consider_a_shutdown(*args, **kwargs):
+            self = cls._current_runner
             worker = self._worker
             worker.__task_finished = True
 
@@ -288,8 +296,8 @@ class WorkerRunner(object):
                 _set_job_watchdog()
 
         # Using weak references. Is up to the caller to clear the callbacks produced
-        self.hooks.extend([_set_broker_watchdog, _set_job_watchdog, _unset_watchdogs, _ack_success, _consider_a_shutdown])
-        return self.hooks
+        cls.hooks.extend([_set_broker_watchdog, _set_job_watchdog, _unset_watchdogs, _ack_success, _consider_a_shutdown])
+        return cls.hooks
 
     def _demand_shutdown(self, *args, **kwargs):
         worker = self._worker


### PR DESCRIPTION
`self` should not be bound to the hooks, as it runs for every worker. It should be bound to the `cls` if any.

Note that the actual implementation does not work for multiple concurrent instances of `WorkerRunner`, as the `_current_runner` is shared.