### PR TITLE
Select queues via  CELERY_SERVERLESS_QUEUES envvar

### DIFF
--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -30,7 +30,11 @@ def worker(event, context, intercom_url=None):
     event = event or {}
     logger.debug('Event: %s', event)
 
-    _worker_runner = WorkerRunner(intercom_url=intercom_url, lambda_context=context, worker_metadata=event)
+    queue_names = os.environ.get('CELERY_SERVERLESS_QUEUES', 'celery')
+    _worker_runner = WorkerRunner(
+        intercom_url=intercom_url, lambda_context=context,
+        worker_metadata=event, queues=queue_names,
+    )
 
     # The Celery worker will start here. Will connect, take 1 (one) task,
     # process it, and quit.

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -61,7 +61,8 @@ def watchdog(event, context):
     if queue_url == 'disabled':
         watched = None
     else:
-        watched = KombuQueueLengther(queue_url, 'celery')   # TODO: Allow queue name to be chosen
+        queue_names = os.environ.get('CELERY_SERVERLESS_QUEUES', 'celery')
+        watched = KombuQueueLengther(queue_url, queue_names)   # TODO: Allow many queues at once
 
     watchdog = Watchdog(communicator=build_intercom(intercom_url), name=lock_name, lock=lock, watched=watched)
 

--- a/celery_serverless/handler.py
+++ b/celery_serverless/handler.py
@@ -62,7 +62,7 @@ def watchdog(event, context):
         watched = None
     else:
         queue_names = os.environ.get('CELERY_SERVERLESS_QUEUES', 'celery')
-        watched = KombuQueueLengther(queue_url, queue_names)   # TODO: Allow many queues at once
+        watched = KombuQueueLengther(queue_url, queue_names)
 
     watchdog = Watchdog(communicator=build_intercom(intercom_url), name=lock_name, lock=lock, watched=watched)
 

--- a/celery_serverless/worker_management.py
+++ b/celery_serverless/worker_management.py
@@ -83,7 +83,7 @@ def remaining_lifetime_getter(lambda_context=None) -> 'float':
 class WorkerRunner(object):
     hooks = []
 
-    def __init__(self, task_max_lifetime=300-15-30, softlimit=30, hardlimit=15,
+    def __init__(self, task_max_lifetime=300-15-30, softlimit=30, hardlimit=15, queues='celery',
                  intercom_url='', lambda_context=None, worker_metadata=None):
         # To store the Worker instance.
         # Sometime it will change to a Thread or Async aware thing
@@ -96,6 +96,7 @@ class WorkerRunner(object):
         self._softlimit = softlimit
         self._hardlimit = hardlimit
         self._task_max_lifetime = task_max_lifetime
+        self._queues = queues.strip().split(',') if hasattr(queues, 'split') else queues
 
         self._intercom_url = intercom_url or os.environ.get('CELERY_SERVERLESS_INTERCOM_URL')
         assert self._intercom_url, 'The CELERY_SERVERLESS_INTERCOM_URL envvar should be set. Even to "disabled" to disable it.'
@@ -231,7 +232,8 @@ class WorkerRunner(object):
             worker.__task_finished = False
 
             # HACK: (Re)start to listen the queue. Could had been silenced before.
-            worker.consumer.add_task_queue('celery')  # TODO: Select the queue dynamically
+            for q in self._queues:
+                worker.consumer.add_task_queue(q)
 
             def _maybe_shutdown(*args, **kwargs):
                 if worker.__task_received:
@@ -268,11 +270,12 @@ class WorkerRunner(object):
             task = sender
             logger.info('Job done. Consider stop receiving new messages avoiding Kombu prefetch. [task_success]')
 
-            worker = self._worker  # TODO: Get the list of queues.
+            worker = self._worker
             if self.is_time_up():
                 self.is_shutting_down = True
                 logger.info('No time for another job. Stop listening the queue! [task_success]')
-                worker.consumer.cancel_task_queue('celery')  # Manually, to prevent the next line to receive a new task
+                for q in self._queues:  # Manually, to prevent the next ack() to receive a new task
+                    worker.consumer.cancel_task_queue(q)
                 task._original_request.message.ack()  # Manually, as WorkerShutdown() will redeliver current message
 
         @task_postrun.connect  # Task finished


### PR DESCRIPTION
`CELERY_SERVERLESS_QUEUES` is a comma-separated string of queue names to be listened.